### PR TITLE
Add missing command to generate the database

### DIFF
--- a/lib/panacea/rails/generator.rb
+++ b/lib/panacea/rails/generator.rb
@@ -244,6 +244,7 @@ module Panacea # :nodoc:
         generate "devise", model_name
         generate "devise:views", plural_model_name if config.dig("devise_override_views")
 
+        rails_command "db:create"
         rails_command "db:migrate"
       end
 


### PR DESCRIPTION
Fixes #2 

Run `db:create` command before running the migration 